### PR TITLE
Fix default language constant

### DIFF
--- a/bot/db_service.py
+++ b/bot/db_service.py
@@ -3,7 +3,7 @@ from bot.config import Config
 from aiogram.types import Message
 
 
-DEFAULT_LANGUAGE = "en"
+DEFAULT_LANGUAGE = "ru"
 DEFAULT_REMINDER_TIME = "12:00"
 DEFAULT_STATE = "start"
 DEFAULT_STATUS = "active"


### PR DESCRIPTION
## Summary
- default language was set to `en` which broke tests expecting `ru`
- update `DEFAULT_LANGUAGE` constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842af6c6c9883248cc9f30391f365a3